### PR TITLE
redirectToCheckout() doesn't use an options object

### DIFF
--- a/src/components/CartSummary.js
+++ b/src/components/CartSummary.js
@@ -36,7 +36,7 @@ const CartSummary = () => {
         setLoading(false);
       });
 
-    redirectToCheckout({ sessionId });
+    redirectToCheckout(sessionId);
   };
 
   return (


### PR DESCRIPTION
I was testing out the demo link provided in the readme. When clicking the checkout button an error is thrown and the user is never sent to checkout. I believe this is the root of the error, as use-shopping-cart's `redirectToCheckout` method takes either nothing or a `sessionId` string (not in the form of an options object).