### PR TITLE
Remove double confirmation

### DIFF
--- a/functions/create-payment-intent.js
+++ b/functions/create-payment-intent.js
@@ -38,7 +38,6 @@ exports.handler = async (event) => {
       amount,
       currency: 'usd',
       ...paymentDetails,
-      confirm: true,
       // We are using the metadata to track which items were purchased.
       // We can access this meatadata in our webhook handler to then handle
       // the fulfillment process.


### PR DESCRIPTION
Remove `confirm:true` in the Netlify function as we confirm client-side: https://github.com/stripe-samples/react-elements-netlify-serverless/blob/master/src/components/PaymentRequest.js#L63-L65